### PR TITLE
feat: backport file deletions and renames to versioned docs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -29954,6 +29954,7 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.run = run;
+exports.deleteVersionedFile = deleteVersionedFile;
 exports.backportFiles = backportFiles;
 exports.checkExistingBackportPR = checkExistingBackportPR;
 exports.createBackportPR = createBackportPR;
@@ -30066,8 +30067,8 @@ async function run() {
             await createBranchForBackport(octokit, context, branchName);
             // Process files and get stats
             const stats = await backportFiles(octokit, context, targetMainFolder, versionedFolder, changedFiles, branchName);
-            // Only create a PR if we successfully copied at least one file
-            if (stats.copied > 0) {
+            // Only create a PR if we successfully copied or deleted at least one file
+            if (stats.copied > 0 || stats.deleted > 0) {
                 // Get original PR title
                 const originalPRTitle = context.payload.pull_request.title;
                 // Create a PR
@@ -30101,20 +30102,80 @@ async function createBranchForBackport(octokit, context, branchName) {
     });
     core.info(`Created branch ${branchName}`);
 }
+// Delete a file from the versioned folder. Returns 'deleted' or 'absent'.
+async function deleteVersionedFile(octokit, context, targetPath, branchName) {
+    // Get the file's current SHA
+    let sha;
+    try {
+        const { data: existingFile } = await octokit.rest.repos.getContent({
+            ...context.repo,
+            path: targetPath,
+            ref: branchName
+        });
+        sha = existingFile.sha;
+    }
+    catch (error) {
+        if (error.status === 404) {
+            core.info(`File already absent in versioned folder: ${targetPath}`);
+            return 'absent';
+        }
+        throw error;
+    }
+    // Delete the file, with SHA conflict retry
+    try {
+        await octokit.rest.repos.deleteFile({
+            ...context.repo,
+            path: targetPath,
+            message: `Backport: Delete ${targetPath} (removed in source)`,
+            sha,
+            branch: branchName
+        });
+    }
+    catch (deleteError) {
+        const isShaConflict = deleteError.status === 409 || deleteError.message?.includes('but expected');
+        if (isShaConflict) {
+            core.info(`SHA conflict on delete for ${targetPath}, retrying...`);
+            const { data: conflictFile } = await octokit.rest.repos.getContent({
+                ...context.repo,
+                path: targetPath,
+                ref: branchName
+            });
+            await octokit.rest.repos.deleteFile({
+                ...context.repo,
+                path: targetPath,
+                message: `Backport: Delete ${targetPath} (removed in source)`,
+                sha: conflictFile.sha,
+                branch: branchName
+            });
+        }
+        else {
+            throw deleteError;
+        }
+    }
+    core.info(`Deleted ${targetPath}`);
+    return 'deleted';
+}
 // Exported for testing
 async function backportFiles(octokit, context, sourceFolder, versionedFolder, files, branchName) {
     // Track stats for reporting
     let copied = 0;
+    let deleted = 0;
     let skipped = 0;
     let errors = 0;
     for (const file of files) {
         try {
             // Extract the relative path within the source folder
             const relativePath = file.filename.substring(sourceFolder.length + 1);
-            // Skip if file was deleted in the PR
+            // Delete file from versioned folder if it was removed in the PR
             if (file.status === 'removed') {
-                core.info(`Skipping deleted file: ${file.filename}`);
-                skipped++;
+                const targetPath = `${versionedFolder}/${relativePath}`;
+                const result = await deleteVersionedFile(octokit, context, targetPath, branchName);
+                if (result === 'deleted') {
+                    deleted++;
+                }
+                else {
+                    skipped++;
+                }
                 continue;
             }
             // Construct the target path in the versioned folder
@@ -30180,6 +30241,19 @@ async function backportFiles(octokit, context, sourceFolder, versionedFolder, fi
             }
             copied++;
             core.info(`Backported ${file.filename} to ${targetPath}`);
+            // For renamed files, also delete the old path from the versioned folder
+            if (file.status === 'renamed' && file.previous_filename) {
+                const oldRelativePath = file.previous_filename.substring(sourceFolder.length + 1);
+                const oldTargetPath = `${versionedFolder}/${oldRelativePath}`;
+                const result = await deleteVersionedFile(octokit, context, oldTargetPath, branchName);
+                if (result === 'deleted') {
+                    deleted++;
+                    core.info(`Deleted old path ${oldTargetPath} after rename`);
+                }
+                else {
+                    core.info(`Old path already absent after rename: ${oldTargetPath}`);
+                }
+            }
         }
         catch (error) {
             errors++;
@@ -30189,10 +30263,11 @@ async function backportFiles(octokit, context, sourceFolder, versionedFolder, fi
     // Create stats object
     const stats = {
         copied,
+        deleted,
         skipped,
         errors
     };
-    core.info(`Backport stats - Copied: ${copied}, Skipped: ${skipped}, Errors: ${errors}`);
+    core.info(`Backport stats - Copied: ${copied}, Deleted: ${deleted}, Skipped: ${skipped}, Errors: ${errors}`);
     // Return the stats
     return stats;
 }

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -411,6 +411,253 @@ describe('Docs Backport Action Tests', () => {
     });
   });
 
+  describe('deleteVersionedFile', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('deletes file when it exists in versioned folder', async () => {
+      const mockOctokit = {
+        rest: {
+          repos: {
+            getContent: jest.fn().mockResolvedValueOnce({ data: { sha: 'existing-sha' } }),
+            deleteFile: jest.fn().mockResolvedValueOnce({})
+          }
+        }
+      };
+      const mockContext = { repo: { owner: 'test', repo: 'test' } };
+
+      const result = await index.deleteVersionedFile(
+        mockOctokit, mockContext, 'vcluster_versioned_docs/version-0.27.0/test.mdx', 'backport/branch'
+      );
+
+      expect(result).toBe('deleted');
+      expect(mockOctokit.rest.repos.deleteFile).toHaveBeenCalledWith(
+        expect.objectContaining({ sha: 'existing-sha', branch: 'backport/branch' })
+      );
+    });
+
+    it('returns absent when file does not exist (404)', async () => {
+      const mockOctokit = {
+        rest: {
+          repos: {
+            getContent: jest.fn().mockRejectedValueOnce({ status: 404 }),
+            deleteFile: jest.fn()
+          }
+        }
+      };
+      const mockContext = { repo: { owner: 'test', repo: 'test' } };
+
+      const result = await index.deleteVersionedFile(
+        mockOctokit, mockContext, 'vcluster_versioned_docs/version-0.27.0/test.mdx', 'backport/branch'
+      );
+
+      expect(result).toBe('absent');
+      expect(mockOctokit.rest.repos.deleteFile).not.toHaveBeenCalled();
+    });
+
+    it('retries delete on SHA conflict', async () => {
+      const mockOctokit = {
+        rest: {
+          repos: {
+            getContent: jest.fn()
+              .mockResolvedValueOnce({ data: { sha: 'old-sha' } })
+              .mockResolvedValueOnce({ data: { sha: 'new-sha' } }),
+            deleteFile: jest.fn()
+              .mockRejectedValueOnce(new Error('is at abc but expected def'))
+              .mockResolvedValueOnce({})
+          }
+        }
+      };
+      const mockContext = { repo: { owner: 'test', repo: 'test' } };
+
+      const result = await index.deleteVersionedFile(
+        mockOctokit, mockContext, 'vcluster_versioned_docs/version-0.27.0/test.mdx', 'backport/branch'
+      );
+
+      expect(result).toBe('deleted');
+      expect(mockOctokit.rest.repos.deleteFile).toHaveBeenCalledTimes(2);
+      expect(mockOctokit.rest.repos.deleteFile).toHaveBeenLastCalledWith(
+        expect.objectContaining({ sha: 'new-sha' })
+      );
+    });
+
+    it('retries delete on HTTP 409', async () => {
+      const error409 = new Error('Conflict') as any;
+      error409.status = 409;
+
+      const mockOctokit = {
+        rest: {
+          repos: {
+            getContent: jest.fn()
+              .mockResolvedValueOnce({ data: { sha: 'old-sha' } })
+              .mockResolvedValueOnce({ data: { sha: 'new-sha' } }),
+            deleteFile: jest.fn()
+              .mockRejectedValueOnce(error409)
+              .mockResolvedValueOnce({})
+          }
+        }
+      };
+      const mockContext = { repo: { owner: 'test', repo: 'test' } };
+
+      const result = await index.deleteVersionedFile(
+        mockOctokit, mockContext, 'vcluster_versioned_docs/version-0.27.0/test.mdx', 'backport/branch'
+      );
+
+      expect(result).toBe('deleted');
+      expect(mockOctokit.rest.repos.deleteFile).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws non-conflict errors', async () => {
+      const mockOctokit = {
+        rest: {
+          repos: {
+            getContent: jest.fn().mockResolvedValueOnce({ data: { sha: 'sha' } }),
+            deleteFile: jest.fn().mockRejectedValueOnce(new Error('server error'))
+          }
+        }
+      };
+      const mockContext = { repo: { owner: 'test', repo: 'test' } };
+
+      await expect(index.deleteVersionedFile(
+        mockOctokit, mockContext, 'path/file.mdx', 'branch'
+      )).rejects.toThrow('server error');
+    });
+  });
+
+  describe('backportFiles with removed files', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('deletes removed file from versioned folder', async () => {
+      const mockOctokit = {
+        rest: {
+          repos: {
+            getContent: jest.fn()
+              .mockResolvedValueOnce({ data: { sha: 'target-sha' } }),
+            deleteFile: jest.fn().mockResolvedValueOnce({})
+          }
+        }
+      };
+
+      const stats = await index.backportFiles(
+        mockOctokit,
+        { repo: { owner: 'test', repo: 'test' }, payload: { pull_request: { head: { sha: 'sha' } } } },
+        'vcluster',
+        'vcluster_versioned_docs/version-0.27.0',
+        [{ filename: 'vcluster/removed.mdx', status: 'removed' }],
+        'backport/branch'
+      );
+
+      expect(stats.deleted).toBe(1);
+      expect(stats.copied).toBe(0);
+      expect(stats.skipped).toBe(0);
+      expect(mockOctokit.rest.repos.deleteFile).toHaveBeenCalled();
+    });
+
+    it('skips removed file when already absent from versioned folder', async () => {
+      const mockOctokit = {
+        rest: {
+          repos: {
+            getContent: jest.fn().mockRejectedValueOnce({ status: 404 }),
+            deleteFile: jest.fn()
+          }
+        }
+      };
+
+      const stats = await index.backportFiles(
+        mockOctokit,
+        { repo: { owner: 'test', repo: 'test' }, payload: { pull_request: { head: { sha: 'sha' } } } },
+        'vcluster',
+        'vcluster_versioned_docs/version-0.27.0',
+        [{ filename: 'vcluster/gone.mdx', status: 'removed' }],
+        'backport/branch'
+      );
+
+      expect(stats.deleted).toBe(0);
+      expect(stats.skipped).toBe(1);
+      expect(mockOctokit.rest.repos.deleteFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('backportFiles with renamed files', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('copies new path and deletes old path for renamed file', async () => {
+      const mockOctokit = {
+        rest: {
+          repos: {
+            getContent: jest.fn()
+              // 1st call: get source content for the new filename
+              .mockResolvedValueOnce({ data: { content: Buffer.from('new content').toString('base64'), sha: 'src' } })
+              // 2nd call: check if new target exists (404 = doesn't exist yet)
+              .mockRejectedValueOnce({ status: 404 })
+              // 3rd call: check if old target exists for deletion
+              .mockResolvedValueOnce({ data: { sha: 'old-target-sha' } }),
+            createOrUpdateFileContents: jest.fn().mockResolvedValueOnce({}),
+            deleteFile: jest.fn().mockResolvedValueOnce({})
+          }
+        }
+      };
+
+      const stats = await index.backportFiles(
+        mockOctokit,
+        { repo: { owner: 'test', repo: 'test' }, payload: { pull_request: { head: { sha: 'sha' } } } },
+        'vcluster',
+        'vcluster_versioned_docs/version-0.27.0',
+        [{
+          filename: 'vcluster/new-name.mdx',
+          previous_filename: 'vcluster/old-name.mdx',
+          status: 'renamed'
+        }],
+        'backport/branch'
+      );
+
+      expect(stats.copied).toBe(1);
+      expect(stats.deleted).toBe(1);
+      expect(stats.errors).toBe(0);
+      expect(mockOctokit.rest.repos.createOrUpdateFileContents).toHaveBeenCalled();
+      expect(mockOctokit.rest.repos.deleteFile).toHaveBeenCalledWith(
+        expect.objectContaining({ path: 'vcluster_versioned_docs/version-0.27.0/old-name.mdx' })
+      );
+    });
+
+    it('copies new path even when old path already absent', async () => {
+      const mockOctokit = {
+        rest: {
+          repos: {
+            getContent: jest.fn()
+              .mockResolvedValueOnce({ data: { content: Buffer.from('content').toString('base64'), sha: 'src' } })
+              .mockRejectedValueOnce({ status: 404 }) // new target doesn't exist
+              .mockRejectedValueOnce({ status: 404 }), // old target also doesn't exist
+            createOrUpdateFileContents: jest.fn().mockResolvedValueOnce({}),
+            deleteFile: jest.fn()
+          }
+        }
+      };
+
+      const stats = await index.backportFiles(
+        mockOctokit,
+        { repo: { owner: 'test', repo: 'test' }, payload: { pull_request: { head: { sha: 'sha' } } } },
+        'vcluster',
+        'vcluster_versioned_docs/version-0.27.0',
+        [{
+          filename: 'vcluster/new-name.mdx',
+          previous_filename: 'vcluster/old-name.mdx',
+          status: 'renamed'
+        }],
+        'backport/branch'
+      );
+
+      expect(stats.copied).toBe(1);
+      expect(stats.deleted).toBe(0);
+      expect(mockOctokit.rest.repos.deleteFile).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Label Processing Logic - Regression Tests', () => {
     it('REGRESSION TEST: multiple labels should not create duplicate PRs', () => {
       // This test verifies the fix for the duplicate PR bug

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
-import * as path from 'path';
 
 // Define main folders and their versioned counterparts
 const FOLDER_MAPPING: Record<string, string> = {
@@ -153,8 +152,8 @@ export async function run(): Promise<void> {
         branchName
       );
       
-      // Only create a PR if we successfully copied at least one file
-      if (stats.copied > 0) {
+      // Only create a PR if we successfully copied or deleted at least one file
+      if (stats.copied > 0 || stats.deleted > 0) {
         // Get original PR title
         const originalPRTitle = context.payload.pull_request.title;
         
@@ -209,8 +208,67 @@ async function createBranchForBackport(
 // Interface for backport statistics
 interface BackportStats {
   copied: number;
+  deleted: number;
   skipped: number;
   errors: number;
+}
+
+// Delete a file from the versioned folder. Returns 'deleted' or 'absent'.
+export async function deleteVersionedFile(
+  octokit: any,
+  context: any,
+  targetPath: string,
+  branchName: string
+): Promise<'deleted' | 'absent'> {
+  // Get the file's current SHA
+  let sha: string;
+  try {
+    const { data: existingFile } = await octokit.rest.repos.getContent({
+      ...context.repo,
+      path: targetPath,
+      ref: branchName
+    });
+    sha = existingFile.sha;
+  } catch (error: any) {
+    if (error.status === 404) {
+      core.info(`File already absent in versioned folder: ${targetPath}`);
+      return 'absent';
+    }
+    throw error;
+  }
+
+  // Delete the file, with SHA conflict retry
+  try {
+    await octokit.rest.repos.deleteFile({
+      ...context.repo,
+      path: targetPath,
+      message: `Backport: Delete ${targetPath} (removed in source)`,
+      sha,
+      branch: branchName
+    });
+  } catch (deleteError: any) {
+    const isShaConflict = deleteError.status === 409 || deleteError.message?.includes('but expected');
+    if (isShaConflict) {
+      core.info(`SHA conflict on delete for ${targetPath}, retrying...`);
+      const { data: conflictFile } = await octokit.rest.repos.getContent({
+        ...context.repo,
+        path: targetPath,
+        ref: branchName
+      });
+      await octokit.rest.repos.deleteFile({
+        ...context.repo,
+        path: targetPath,
+        message: `Backport: Delete ${targetPath} (removed in source)`,
+        sha: conflictFile.sha,
+        branch: branchName
+      });
+    } else {
+      throw deleteError;
+    }
+  }
+
+  core.info(`Deleted ${targetPath}`);
+  return 'deleted';
 }
 
 // Exported for testing
@@ -224,21 +282,27 @@ export async function backportFiles(
 ): Promise<BackportStats> {
   // Track stats for reporting
   let copied = 0;
+  let deleted = 0;
   let skipped = 0;
   let errors = 0;
-  
+
   for (const file of files) {
     try {
       // Extract the relative path within the source folder
       const relativePath = file.filename.substring(sourceFolder.length + 1);
-      
-      // Skip if file was deleted in the PR
+
+      // Delete file from versioned folder if it was removed in the PR
       if (file.status === 'removed') {
-        core.info(`Skipping deleted file: ${file.filename}`);
-        skipped++;
+        const targetPath = `${versionedFolder}/${relativePath}`;
+        const result = await deleteVersionedFile(octokit, context, targetPath, branchName);
+        if (result === 'deleted') {
+          deleted++;
+        } else {
+          skipped++;
+        }
         continue;
       }
-      
+
       // Construct the target path in the versioned folder
       // For your structure, we need to copy to version-vX.Y.Z/[original path]
       const targetPath = `${versionedFolder}/${relativePath}`;
@@ -306,20 +370,34 @@ export async function backportFiles(
 
       copied++;
       core.info(`Backported ${file.filename} to ${targetPath}`);
+
+      // For renamed files, also delete the old path from the versioned folder
+      if (file.status === 'renamed' && file.previous_filename) {
+        const oldRelativePath = file.previous_filename.substring(sourceFolder.length + 1);
+        const oldTargetPath = `${versionedFolder}/${oldRelativePath}`;
+        const result = await deleteVersionedFile(octokit, context, oldTargetPath, branchName);
+        if (result === 'deleted') {
+          deleted++;
+          core.info(`Deleted old path ${oldTargetPath} after rename`);
+        } else {
+          core.info(`Old path already absent after rename: ${oldTargetPath}`);
+        }
+      }
     } catch (error: any) {
       errors++;
       core.warning(`Error backporting file ${file.filename}: ${error.message}`);
     }
   }
-  
+
   // Create stats object
   const stats: BackportStats = {
     copied,
+    deleted,
     skipped,
     errors
   };
-  
-  core.info(`Backport stats - Copied: ${copied}, Skipped: ${skipped}, Errors: ${errors}`);
+
+  core.info(`Backport stats - Copied: ${copied}, Deleted: ${deleted}, Skipped: ${skipped}, Errors: ${errors}`);
   
   // Return the stats
   return stats;


### PR DESCRIPTION
## Summary

- Backport file deletions: when a page is removed in `main`, the corresponding versioned copy is now deleted instead of being skipped
- Backport file renames: when a file is renamed, the old path is deleted from the versioned folder after copying content to the new path
- SHA conflict retry logic mirrors the existing pattern for create/update operations
- PR creation now triggers for deletion-only backports (not just copies)

## Design decisions

**Delete-if-exists semantics**: if the target file exists in the versioned folder, delete it unconditionally. No content comparison. This matches the action's existing "main is the source of truth" philosophy.

**Renamed files**: GitHub returns `renamed` as a single entry with `filename` (new) and `previous_filename` (old). The action now copies the new path AND deletes the old path in one pass.

**Empty directories**: after deletion, empty parent directories are left in place. Docusaurus tolerates them and Git doesn't track empty dirs anyway.

## Test plan

- [x] Unit tests for `deleteVersionedFile` (exists, absent/404, SHA conflict retry, non-conflict error)
- [x] Unit tests for `backportFiles` with `removed` status (target exists → delete, target absent → skip)
- [x] Unit tests for `backportFiles` with `renamed` status (copy new + delete old, old already absent)
- [x] All 24 tests pass, lint clean, build succeeds

Closes DEVOPS-779