### PR TITLE
fix: use merge_commit_sha when reading file content for backports

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30182,11 +30182,15 @@ async function backportFiles(octokit, context, sourceFolder, versionedFolder, fi
             // For your structure, we need to copy to version-vX.Y.Z/[original path]
             const targetPath = `${versionedFolder}/${relativePath}`;
             core.info(`Backporting ${file.filename} to ${targetPath}`);
-            // Get the file content from the PR's head branch
+            // Get the file content from the merge commit on the base branch.
+            // Using head.sha would capture the pre-merge state and miss changes
+            // that the 3-way merge reconciliation applied on main (e.g. deletions
+            // silently restored, paths altered). merge_commit_sha is populated for
+            // merged PRs across squash, merge-commit, and rebase strategies.
             const { data: content } = await octokit.rest.repos.getContent({
                 ...context.repo,
                 path: file.filename,
-                ref: context.payload.pull_request.head.sha
+                ref: context.payload.pull_request.merge_commit_sha
             });
             // Check if the target file already exists to get its SHA
             let sha = '';

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -340,7 +340,7 @@ describe('Docs Backport Action Tests', () => {
 
       const stats = await index.backportFiles(
         mockOctokit,
-        { repo: { owner: 'test', repo: 'test' }, payload: { pull_request: { head: { sha: 'sha' } } } },
+        { repo: { owner: 'test', repo: 'test' }, payload: { pull_request: { head: { sha: 'sha' }, merge_commit_sha: 'merge-sha' } } },
         'vcluster',
         'vcluster_versioned_docs/version-0.27.0',
         [{ filename: 'vcluster/test.mdx', status: 'added' }],
@@ -349,6 +349,39 @@ describe('Docs Backport Action Tests', () => {
 
       expect(stats.copied).toBe(1);
       expect(stats.errors).toBe(0);
+    });
+
+    it('reads source content from merge_commit_sha, not head.sha', async () => {
+      // Regression for DEVOPS-855: backports must reflect the post-merge state
+      // (3-way merge reconciliation on main) rather than the PR branch tip.
+      // Reproduces vcluster-docs PR #1963 scenario where head.sha captured a
+      // deletion that the merge silently restored.
+      const mockOctokit = {
+        rest: {
+          repos: {
+            getContent: jest.fn()
+              .mockResolvedValueOnce({ data: { content: Buffer.from('test').toString('base64'), sha: 'src' } })
+              .mockRejectedValueOnce({ status: 404 }),
+            createOrUpdateFileContents: jest.fn().mockResolvedValueOnce({})
+          }
+        }
+      };
+
+      await index.backportFiles(
+        mockOctokit,
+        { repo: { owner: 'test', repo: 'test' }, payload: { pull_request: { head: { sha: 'head-sha' }, merge_commit_sha: 'merge-sha' } } },
+        'vcluster',
+        'vcluster_versioned_docs/version-0.27.0',
+        [{ filename: 'vcluster/test.mdx', status: 'added' }],
+        'backport/branch'
+      );
+
+      expect(mockOctokit.rest.repos.getContent).toHaveBeenNthCalledWith(1,
+        expect.objectContaining({ path: 'vcluster/test.mdx', ref: 'merge-sha' })
+      );
+      expect(mockOctokit.rest.repos.getContent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ path: 'vcluster/test.mdx', ref: 'head-sha' })
+      );
     });
 
     it('retries with correct SHA on conflict (message pattern)', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -309,11 +309,15 @@ export async function backportFiles(
       
       core.info(`Backporting ${file.filename} to ${targetPath}`);
       
-      // Get the file content from the PR's head branch
+      // Get the file content from the merge commit on the base branch.
+      // Using head.sha would capture the pre-merge state and miss changes
+      // that the 3-way merge reconciliation applied on main (e.g. deletions
+      // silently restored, paths altered). merge_commit_sha is populated for
+      // merged PRs across squash, merge-commit, and rebase strategies.
       const { data: content } = await octokit.rest.repos.getContent({
         ...context.repo,
         path: file.filename,
-        ref: context.payload.pull_request.head.sha
+        ref: context.payload.pull_request.merge_commit_sha
       });
       
       // Check if the target file already exists to get its SHA


### PR DESCRIPTION
## Summary

`backportFiles()` was reading file content via `head.sha` (the PR branch tip) instead of `merge_commit_sha` (the actual commit landed on `main` after 3-way merge reconciliation). When the merge resolved against `main` in a way that altered the PR's diff — restoring deletions, changing paths — the backport captured the pre-merge state and broke the versioned builds.

Reproduced by vcluster-docs PR #1963: the slug-removal commit was silently undone by the merge, but the backport PRs ([#2008](https://github.com/loft-sh/vcluster-docs/pull/2008), [#2009](https://github.com/loft-sh/vcluster-docs/pull/2009)) still carried the removal and broke Netlify on both versioned branches.

`merge_commit_sha` is populated for any merged PR across squash, merge-commit, and rebase strategies. The `merged === true` gate in `run()` (`src/index.ts:38, 54, 64`) guarantees it is present when `backportFiles()` executes — no null-guard needed.

## Key Changes

- `src/index.ts` — change `ref` argument to `octokit.rest.repos.getContent` from `context.payload.pull_request.head.sha` to `...merge_commit_sha` inside `backportFiles()`
- `src/__tests__/index.test.ts` — add regression test asserting `getContent` is called with `merge_commit_sha` and not `head.sha`
- `dist/index.js` — rebuilt bundle (required for compiled GitHub Action)

## Dependencies

None.

## TODO

- [x] update source
- [x] add regression test
- [x] rebuild `dist/`
- [x] all tests pass (25/25)
- [x] lint clean

Closes DEVOPS-855