### PR TITLE
fix: paginate changed file listing for backports

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -29954,6 +29954,7 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.run = run;
+exports.listChangedFiles = listChangedFiles;
 exports.deleteVersionedFile = deleteVersionedFile;
 exports.backportFiles = backportFiles;
 exports.checkExistingBackportPR = checkExistingBackportPR;
@@ -29966,7 +29967,10 @@ const FOLDER_MAPPING = {
     'vcluster': 'vcluster_versioned_docs'
 };
 // Regular expression to match version labels (e.g., backport-v0.22, backport-v4.2)
-const VERSION_LABEL_REGEX = /^backport-v([\d\.]+)$/;
+const VERSION_LABEL_REGEX = /^backport-v([\d.]+)$/;
+// GitHub's pulls.listFiles endpoint returns 30 files per page by default and
+// serves at most 100 per page.
+const FILES_PER_PAGE = 100;
 // Main function, exported for testing
 async function run() {
     try {
@@ -30020,10 +30024,8 @@ async function run() {
             return;
         }
         // Get changed files from the PR
-        const { data: files } = await octokit.rest.pulls.listFiles({
-            ...context.repo,
-            pull_number: prNumber
-        });
+        const files = await listChangedFiles(octokit, context, prNumber);
+        core.info(`PR #${prNumber} has ${files.length} changed files`);
         // Group files by main folder
         const filesByFolder = {};
         for (const mainFolder of Object.keys(FOLDER_MAPPING)) {
@@ -30082,6 +30084,19 @@ async function run() {
     catch (error) {
         core.setFailed(`Action failed: ${error.message}`);
     }
+}
+// Fetch every changed file in the PR, following pagination.
+// An unpaginated listFiles call returns only the first 30 files, and the files
+// past that boundary vanish before the backport loop starts: they are never
+// copied, never logged as skipped, and never counted as errors, so the backport
+// PR looks complete while quietly carrying stale or missing pages.
+// Exported for testing
+async function listChangedFiles(octokit, context, prNumber) {
+    return octokit.paginate(octokit.rest.pulls.listFiles, {
+        ...context.repo,
+        pull_number: prNumber,
+        per_page: FILES_PER_PAGE
+    });
 }
 async function createBranchForBackport(octokit, context, branchName) {
     // Get the default branch

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -4,7 +4,6 @@
 import './setup';
 // Import the index module
 import * as index from '../index';
-
 // Export backportFiles for testing - we need to test it directly
 // Since it's not exported, we'll test via the run() function behavior
 
@@ -688,6 +687,90 @@ describe('Docs Backport Action Tests', () => {
       expect(stats.copied).toBe(1);
       expect(stats.deleted).toBe(0);
       expect(mockOctokit.rest.repos.deleteFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listChangedFiles', () => {
+    const mockContext = { repo: { owner: 'loft-sh', repo: 'vcluster-docs' } };
+
+    // Build a list of changed files under the vcluster/ prefix
+    const makeFiles = (count: number) =>
+      Array.from({ length: count }, (_, i) => ({
+        filename: `vcluster/doc-${i}.mdx`,
+        status: 'modified'
+      }));
+
+    it('uses Octokit pagination for the complete changed-file list', async () => {
+      const listFiles = jest.fn();
+      const paginate = jest.fn().mockResolvedValue(makeFiles(136));
+      const mockOctokit = { paginate, rest: { pulls: { listFiles } } };
+
+      const files = await index.listChangedFiles(mockOctokit, mockContext, 2475);
+
+      expect(files).toHaveLength(136);
+      expect(paginate).toHaveBeenCalledWith(
+        listFiles,
+        expect.objectContaining({
+          owner: 'loft-sh',
+          repo: 'vcluster-docs',
+          pull_number: 2475,
+          per_page: 100
+        })
+      );
+    });
+
+    it('does not impose a client-side file or page limit', async () => {
+      const listFiles = jest.fn();
+      const paginate = jest.fn().mockResolvedValue(makeFiles(3500));
+      const mockOctokit = { paginate, rest: { pulls: { listFiles } } };
+
+      const files = await index.listChangedFiles(mockOctokit, mockContext, 2475);
+
+      expect(files).toHaveLength(3500);
+    });
+
+    it('REGRESSION TEST: backports every file of a PR with more than 30 changed files', async () => {
+      // Reproduces loft-sh/vcluster-docs#2475: 36 changed files, of which the
+      // last 6 fell past the unpaginated first page and were silently dropped
+      // from the backport PR, four of them left stale and two never created.
+      const listFiles = jest.fn();
+      const paginate = jest.fn().mockResolvedValue(makeFiles(36));
+      const mockOctokit = {
+        paginate,
+        rest: {
+          pulls: { listFiles },
+          repos: {
+            getContent: jest.fn().mockImplementation(({ path }: any) =>
+              path.startsWith('vcluster_versioned_docs/')
+                ? Promise.reject({ status: 404 }) // target file not there yet
+                : Promise.resolve({
+                    data: { content: Buffer.from('content').toString('base64'), sha: 'src' }
+                  })
+            ),
+            createOrUpdateFileContents: jest.fn().mockResolvedValue({})
+          }
+        }
+      };
+
+      const files = await index.listChangedFiles(mockOctokit, mockContext, 2475);
+      expect(files).toHaveLength(36);
+
+      const stats = await index.backportFiles(
+        mockOctokit,
+        { ...mockContext, payload: { pull_request: { merge_commit_sha: 'merge-sha' } } },
+        'vcluster',
+        'vcluster_versioned_docs/version-0.36.0',
+        files,
+        'backport/branch'
+      );
+
+      expect(stats.copied).toBe(36);
+      expect(stats.errors).toBe(0);
+      expect(mockOctokit.rest.repos.createOrUpdateFileContents).toHaveBeenCalledTimes(36);
+      // The files past the first page reach the versioned folder too
+      expect(mockOctokit.rest.repos.createOrUpdateFileContents).toHaveBeenCalledWith(
+        expect.objectContaining({ path: 'vcluster_versioned_docs/version-0.36.0/doc-35.mdx' })
+      );
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,11 @@ const FOLDER_MAPPING: Record<string, string> = {
 };
 
 // Regular expression to match version labels (e.g., backport-v0.22, backport-v4.2)
-const VERSION_LABEL_REGEX = /^backport-v([\d\.]+)$/;
+const VERSION_LABEL_REGEX = /^backport-v([\d.]+)$/;
+
+// GitHub's pulls.listFiles endpoint returns 30 files per page by default and
+// serves at most 100 per page.
+const FILES_PER_PAGE = 100;
 
 // Type for a GitHub label
 interface GitHubLabel {
@@ -80,11 +84,9 @@ export async function run(): Promise<void> {
     }
     
     // Get changed files from the PR
-    const { data: files } = await octokit.rest.pulls.listFiles({
-      ...context.repo,
-      pull_number: prNumber
-    });
-    
+    const files = await listChangedFiles(octokit, context, prNumber);
+    core.info(`PR #${prNumber} has ${files.length} changed files`);
+
     // Group files by main folder
     const filesByFolder: Record<string, typeof files> = {};
     for (const mainFolder of Object.keys(FOLDER_MAPPING)) {
@@ -177,9 +179,30 @@ export async function run(): Promise<void> {
   }
 }
 
+// Fetch every changed file in the PR, following pagination.
+// An unpaginated listFiles call returns only the first 30 files, and the files
+// past that boundary vanish before the backport loop starts: they are never
+// copied, never logged as skipped, and never counted as errors, so the backport
+// PR looks complete while quietly carrying stale or missing pages.
+// Exported for testing
+export async function listChangedFiles(
+  octokit: any,
+  context: any,
+  prNumber: number
+): Promise<any[]> {
+  return octokit.paginate(
+    octokit.rest.pulls.listFiles,
+    {
+      ...context.repo,
+      pull_number: prNumber,
+      per_page: FILES_PER_PAGE
+    }
+  );
+}
+
 async function createBranchForBackport(
-  octokit: any, 
-  context: any, 
+  octokit: any,
+  context: any,
   branchName: string
 ): Promise<void> {
   // Get the default branch


### PR DESCRIPTION
## Problem

Backport PRs silently dropped every changed file after the first 30 because `pulls.listFiles` was called without pagination. Files past page one never reached the copy loop, logs, or backport statistics.

## Change

- Fetch the complete changed-file list with `octokit.paginate(...)` and `per_page: 100`.
- Apply no client-side file or page cutoff.
- Log the fetched file count before grouping and backporting files.
- Rebuild `dist/` with the lockfile toolchain.

## Tests

Three pagination regression cases, 28 tests passing in total:

- verifies the action delegates the full fetch to Octokit pagination
- verifies the client preserves a returned list of 3,500 files without truncation
- verifies all 36 files in the reported regression case reach the backport copy loop, including file 36

Also verified after rebasing onto current `main`:

- `npm ci`
- `npm test -- --runInBand`
- targeted ESLint for the changed source and test
- `tsc --noEmit`
- `npm run build`
- rebuilt `dist/index.js` matches the committed artifact

## Delivery dependency

After this PR merges, publish the next compatible v1 release. The release workflow moves the floating `v1` tag. The dependent vcluster-docs PR loft-sh/vcluster-docs#2564 switches the consumer back to `loft-sh/docs-backport-action@v1`.

References DEVOPS-1334
