### PR TITLE
fix(release): publish action tags without pushing main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -26,11 +29,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
           
-      - name: Setup Git
-        run: |
-          git config --global user.email "loft-bot@users.noreply.github.com"
-          git config --global user.name "Loft Bot"
-          
       - name: Install dependencies
         run: npm ci
         
@@ -41,34 +39,25 @@ jobs:
         run: npm run build
         
       - name: Validate version format
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
         run: |
-          if [[ ! "${{ github.event.inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ! "$RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid version format. Please use the format vX.Y.Z (e.g., v1.0.0)"
             exit 1
           fi
-        
-      - name: Update version in package.json
-        run: |
-          VERSION="${{ github.event.inputs.version }}"
-          VERSION_WITHOUT_V="${VERSION#v}"
-          npm version $VERSION_WITHOUT_V --no-git-tag-version
-          
-      - name: Commit and push changes
-        run: |
-          git add package.json package-lock.json
-          git commit -m "Release ${{ github.event.inputs.version }}"
-          git tag ${{ github.event.inputs.version }}
-          git push origin main
-          git push origin ${{ github.event.inputs.version }}
-          
+
       - name: Create GitHub release
-        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.event.inputs.version }}
-          release_name: Release ${{ github.event.inputs.version }}
-          draft: false
-          prerelease: false
-          body: |
-            See [CHANGELOG](https://github.com/loft-sh/docs-backport-action/blob/main/README.md) for details.
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          gh release create "$RELEASE_VERSION" \
+            --target "$GITHUB_SHA" \
+            --title "Release $RELEASE_VERSION" \
+            --generate-notes
+
+      - name: Update floating v1 tag
+        run: |
+          git tag --force v1 "$GITHUB_SHA"
+          git push --force origin v1

--- a/src/__tests__/release-workflow.test.ts
+++ b/src/__tests__/release-workflow.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+describe("release workflow", () => {
+  const workflow = readFileSync(
+    resolve(".github/workflows/release.yml"),
+    "utf8",
+  );
+
+  it("creates a versioned release and advances the floating v1 tag", () => {
+    expect(workflow).toContain("contents: write");
+    expect(workflow).toContain('gh release create "$RELEASE_VERSION"');
+    expect(workflow).toContain('--target "$GITHUB_SHA"');
+    expect(workflow).toContain('git tag --force v1 "$GITHUB_SHA"');
+    expect(workflow).toContain("git push --force origin v1");
+  });
+
+  it("does not commit release metadata directly to the protected branch", () => {
+    expect(workflow).not.toContain("npm version");
+    expect(workflow).not.toContain("git push origin main");
+    expect(workflow).not.toContain("actions/create-release");
+  });
+});


### PR DESCRIPTION
## Summary

- publish versioned action releases at the tested commit
- advance the floating `v1` tag in the same workflow
- stop committing package metadata and pushing directly to protected `main`

The previous release workflow passed tests and build for `v1.3.2`, then failed because repository rules require changes to `main` to arrive through a pull request. The release was recovered with the same tag-based flow implemented here.

## Test plan

- `npm test -- --runInBand` (30 tests pass)
- ESLint on the new release workflow test
- `tsc --noEmit`
- `actionlint .github/workflows/release.yml`
- zizmor reviewed; existing findings are the repository's tag-based `actions/checkout@v7` and `actions/setup-node@v6` references

References DEVOPS-1334
